### PR TITLE
Add blog posts section and visitor badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@
 </p>
 
 I recently graduated from the [University of Cambridge](https://www.cam.ac.uk) with a BA in Mathematics. I've since been working as a software engineer at [QuantumBlack](https://quantumblack.com), specifically within [QuantumBlack Labs](https://github.com/quantumblacklabs) across a variety of our products, including [Kedro](https://github.com/quantumblacklabs/kedro), our open source development workflow framework. I'm an avid open source contributor, as a core developer on [Zarr](https://github.com/zarr-developers/zarr-python) and numerous open source contributions to various frameworks and libraries.
+
+### Blog posts
+
+You can find my (irregular) blogging over at [zainp.com/blog](https://zainp.com/blog) where I talk about everything from experimenting with Golang to some of Kedro's new features to hacking around with my banking app.
+
+<img src="https://visitor-badge.glitch.me/badge?page_id=mzjp2.visitor-badge">


### PR DESCRIPTION
This PR adds in the blog posts section in my README which redirects to my personal website and a visitor badge to keep track of visitors.